### PR TITLE
feat(sdk): sign a hash during passkey creation and return signature

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -6,7 +6,7 @@
       "name": "yoanslvy"
     }
   ],
-  "version": "1.0.26",
+  "version": "1.0.27-dev.1",
   "description": "SDK Cometh Connect 4337",
   "repository": "https://github.com/cometh-hq/connect-sdk-4337.git",
   "keywords": [

--- a/packages/sdk/src/core/actions/accounts/addNewDevice.ts
+++ b/packages/sdk/src/core/actions/accounts/addNewDevice.ts
@@ -5,11 +5,14 @@ import { encryptSignerInStorage } from "@/core/signers/ecdsa/services/ecdsaServi
 import {
     createPasskeySigner,
     setPasskeyInStorage,
+    sign,
 } from "@/core/signers/passkeys/passkeyService";
 import type { webAuthnOptions } from "@/core/signers/passkeys/types";
 import {
     DEFAULT_WEBAUTHN_OPTIONS,
+    assertValidHash,
     isWebAuthnCompatible,
+    parseHex,
 } from "@/core/signers/passkeys/utils";
 import type { Signer } from "@/core/types";
 import {
@@ -38,6 +41,7 @@ export type CreateNewSignerParams = {
     passKeyName?: string;
     fullDomainSelected?: boolean;
     encryptionSalt?: string;
+    hash?: Hex;
 };
 
 const _flattenPayload = (signerPayload: Signer): Record<string, string> => {
@@ -77,6 +81,10 @@ const _flattenPayload = (signerPayload: Signer): Record<string, string> => {
  * @param passKeyName - Optional name for the passkey
  * @param encryptionSalt - Optional encryption salt
  * @param fullDomainSelected - Optional selected the full domain for the passkey
+ * @param hash - Optional 32-byte 0x-prefixed hash. When provided, the freshly
+ * created passkey signs it in a second WebAuthn ceremony and the resulting
+ * signature is returned alongside the signer. Disables the EOA fallback:
+ * throws DeviceNotCompatibleWithPasskeysError if WebAuthn is unavailable.
  */
 export const createNewSignerWithAccountAddress = async ({
     apiKey,
@@ -88,13 +96,18 @@ export const createNewSignerWithAccountAddress = async ({
     smartAccountAddress: Address;
     baseUrl?: string;
     params?: CreateNewSignerParams;
-}): Promise<Signer> => {
+}): Promise<Signer & { signature?: Hex }> => {
+    if (params.hash) assertValidHash(params.hash);
+
     const api = new API(apiKey, baseUrl);
-    const { signer, localPrivateKey } = await _createNewSigner(api, {
+    const signerOptions = {
         passKeyName: params.passKeyName,
         webAuthnOptions: params.webAuthnOptions,
         fullDomainSelected: params.fullDomainSelected ?? false,
-    });
+    };
+    const { signer, localPrivateKey } = params.hash
+        ? await _createNewPasskeySigner(api, signerOptions)
+        : await _createNewSigner(api, signerOptions);
 
     if (signer.publicKeyId) {
         const { publicKeyId, publicKeyX, publicKeyY, signerAddress } = signer;
@@ -118,7 +131,18 @@ export const createNewSignerWithAccountAddress = async ({
             params.encryptionSalt
         );
     }
-    return signer;
+
+    if (!params.hash) return signer;
+    if (!signer.publicKeyId) throw new InvalidSignerDataError();
+
+    const signature = await _signHashWithPasskey({
+        hash: params.hash,
+        publicKeyId: signer.publicKeyId,
+        fullDomainSelected: params.fullDomainSelected ?? false,
+        tauriOptions: params.webAuthnOptions?.tauriOptions,
+    });
+
+    return { ...signer, signature };
 };
 
 /**
@@ -128,6 +152,9 @@ export const createNewSignerWithAccountAddress = async ({
  * @param passKeyName - Optional name for the passkey
  * @param encryptionSalt - Optional encryption salt
  * @param fullDomainSelected - Optional selected the full domain for the passkey
+ * @param hash - Optional 32-byte 0x-prefixed hash. When provided, the freshly
+ * created passkey signs it in a second WebAuthn ceremony and the resulting
+ * signature is returned alongside the signer.
  */
 export const createNewSigner = async ({
     apiKey,
@@ -137,7 +164,9 @@ export const createNewSigner = async ({
     apiKey: string;
     baseUrl?: string;
     params?: CreateNewSignerParams;
-}): Promise<Signer> => {
+}): Promise<Signer & { signature?: Hex }> => {
+    if (params.hash) assertValidHash(params.hash);
+
     const api = new API(apiKey, baseUrl);
     const { signer } = await _createNewPasskeySigner(api, {
         webAuthnOptions: params.webAuthnOptions,
@@ -145,7 +174,17 @@ export const createNewSigner = async ({
         fullDomainSelected: params.fullDomainSelected ?? false,
     });
 
-    return signer;
+    if (!params.hash) return signer;
+    if (!signer.publicKeyId) throw new InvalidSignerDataError();
+
+    const signature = await _signHashWithPasskey({
+        hash: params.hash,
+        publicKeyId: signer.publicKeyId,
+        fullDomainSelected: params.fullDomainSelected ?? false,
+        tauriOptions: params.webAuthnOptions?.tauriOptions,
+    });
+
+    return { ...signer, signature };
 };
 
 export const serializeUrlWithSignerPayload = async (
@@ -281,4 +320,29 @@ const _createNewSigner = async (
         },
         localPrivateKey: privateKey,
     };
+};
+
+const _signHashWithPasskey = async ({
+    hash,
+    publicKeyId,
+    fullDomainSelected,
+    tauriOptions,
+}: {
+    hash: Hex;
+    publicKeyId: Hex;
+    fullDomainSelected: boolean;
+    tauriOptions?: webAuthnOptions["tauriOptions"];
+}): Promise<Hex> => {
+    const publicKeyCredential = [
+        { id: parseHex(publicKeyId), type: "public-key" },
+    ] as PublicKeyCredentialDescriptor[];
+
+    const { signature } = await sign({
+        challenge: hash,
+        publicKeyCredential,
+        fullDomainSelected,
+        tauriOptions,
+    });
+
+    return signature;
 };

--- a/packages/sdk/src/core/actions/accounts/retrieveAccountAddressFromPasskey.ts
+++ b/packages/sdk/src/core/actions/accounts/retrieveAccountAddressFromPasskey.ts
@@ -4,29 +4,14 @@ import {
     retrieveSmartAccountAddressFromPasskeyId,
 } from "@/core/signers/passkeys/passkeyService";
 import type { webAuthnOptions } from "@/core/signers/passkeys/types";
-import { InvalidParamsError } from "@/errors";
+import { assertValidHash } from "@/core/signers/passkeys/utils";
 import { LEGACY_API } from "@/migrationKit/services/LEGACY_API";
-import {
-    type Address,
-    type Chain,
-    type Hex,
-    type PublicClient,
-    isHex,
-    size,
-} from "viem";
+import type { Address, Chain, Hex, PublicClient } from "viem";
 
 export type RetrieveAccountAddressWithSignatureResponse = {
     smartAccountAddress: Address;
     signature: Hex;
     publicKeyId: Hex;
-};
-
-const _assertValidHash = (hash: Hex): void => {
-    if (!isHex(hash) || size(hash) !== 32) {
-        throw new InvalidParamsError(
-            "hash must be a 32-byte 0x-prefixed hex string"
-        );
-    }
 };
 
 type RetrieveFromPasskeysParams = {
@@ -146,7 +131,7 @@ export const retrieveAccountAddressFromPasskeyId = async (
 export const retrieveAccountAddressFromPasskeysWithSignature = async (
     params: RetrieveFromPasskeysParams & { hash: Hex }
 ): Promise<RetrieveAccountAddressWithSignatureResponse> => {
-    _assertValidHash(params.hash);
+    assertValidHash(params.hash);
 
     const { smartAccountAddress, signature, publicKeyId } =
         await _retrieveFromPasskeys(params);
@@ -166,7 +151,7 @@ export const retrieveAccountAddressFromPasskeysWithSignature = async (
 export const retrieveAccountAddressFromPasskeyIdWithSignature = async (
     params: RetrieveFromPasskeyIdParams & { hash: Hex }
 ): Promise<RetrieveAccountAddressWithSignatureResponse> => {
-    _assertValidHash(params.hash);
+    assertValidHash(params.hash);
 
     const { smartAccountAddress, signature, publicKeyId } =
         await _retrieveFromPasskeyId(params);

--- a/packages/sdk/src/core/signers/passkeys/utils.ts
+++ b/packages/sdk/src/core/signers/passkeys/utils.ts
@@ -1,9 +1,10 @@
 import * as psl from "psl";
-import { maxUint256, toBytes, toHex } from "viem";
+import { type Hex, isHex, maxUint256, size, toBytes, toHex } from "viem";
 
 import { getDeviceData } from "@/core/services/deviceService";
 import {
     ChallengeNotFoundError,
+    InvalidParamsError,
     InvalidSignatureEncodingError,
 } from "@/errors";
 import type { webAuthnOptions } from "./types";
@@ -31,6 +32,14 @@ export const rpId = (): { name: string; id?: string } => {
               id: rootDomain,
           }
         : { name: "localhost" };
+};
+
+export const assertValidHash = (hash: Hex): void => {
+    if (!isHex(hash) || size(hash) !== 32) {
+        throw new InvalidParamsError(
+            "hash must be a 32-byte 0x-prefixed hex string"
+        );
+    }
 };
 
 export const hexArrayStr = (array: ArrayBuffer): string =>


### PR DESCRIPTION
- add optional `hash` param to createNewSigner and createNewSignerWithAccountAddress
- when hash provided: sign it via a 2nd WebAuthn ceremony with the freshly-created passkey
- disable EOA fallback in createNewSignerWithAccountAddress when hash is set (passkey-only)
- return type widens to Signer & { signature?: Hex }
- extract assertValidHash to shared utils (used by retrieve and creation)
- replace `as Hex` cast with explicit guard on signer.publicKeyId (fail fast)